### PR TITLE
Remove hard-coded CSV append

### DIFF
--- a/src/main/java/br/com/metricminer2/persistence/csv/CSVFile.java
+++ b/src/main/java/br/com/metricminer2/persistence/csv/CSVFile.java
@@ -31,7 +31,7 @@ public class CSVFile implements PersistenceMechanism {
 
 	public CSVFile(String fileName, boolean append) {
 		try {
-			ps = new PrintStream(new FileOutputStream(fileName, true));
+			ps = new PrintStream(new FileOutputStream(fileName, append));
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
Noticed that we can specify a boolean to enable/disable appending to the CSV, however, this value is not passed to `FileOutputStream`. 